### PR TITLE
Mirror Python API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ mcp_proxy-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
-/mcp_proxy
+# Escript
+/mcp-proxy

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# McpProxy
+# mcp-proxy
 
-<!-- MDOC !-->
-
-An escript for connecting STDIO based MCP clients to HTTP (SSE) based MCP servers.
+An Elixir escript for connecting STDIO based MCP clients to HTTP (SSE) based MCP servers.
 
 Note: At the moment this only works with MCP servers that use the `2024-11-05` specification.
 
@@ -12,18 +10,16 @@ Note: At the moment this only works with MCP servers that use the `2024-11-05` s
 $ mix escript.install hex mcp_proxy
 ```
 
-The escript is installed into your HOME's `.mix` directory: `/path/to/home/.mix/escripts/mcp_proxy`.
+The escript is installed into your HOME's `.mix` directory: `/path/to/home/.mix/escripts/mcp-proxy`. It is advised to add the escripts directory to your `$PATH` but you can use the full path if preferred.
 
-If you have an SSE MCP server available at `http://localhost:4000/mcp`, a client like Claude Desktop would then be configured like this:
+If you have an SSE MCP server available at `http://localhost:4000/tidewave/mcp`, a client like Claude Desktop would then be configured like this:
 
 ```json
 {
   "mcpServers": {
     "my-server": {
-      "command": "/path/to/home/.mix/escripts/mcp_proxy",
-      "env": {
-        "SSE_URL": "http://localhost:4000/mcp"
-      }
+      "command": "/path/to/home/.mix/escripts/mcp-proxy",
+      "args": ["http://localhost:4000/tidewave/mcp"]
     }
   }
 }
@@ -31,4 +27,4 @@ If you have an SSE MCP server available at `http://localhost:4000/mcp`, a client
 
 ## Configuration
 
-`mcp_proxy` either accepts the SSE URL as parameter `--url` or using the environment variable `SSE_URL`. For debugging purposes, you can also pass `--debug`, which will log debug messages on stderr.
+`mcp-proxy` either accepts the SSE URL as argument or using the environment variable `SSE_URL`. For debugging purposes, you can also pass `--debug`, which will log debug messages on stderr.

--- a/lib/mcp_proxy.ex
+++ b/lib/mcp_proxy.ex
@@ -1,25 +1,23 @@
 defmodule McpProxy do
-  @external_resource "README.md"
-  @moduledoc @external_resource
-             |> File.read!()
-             |> String.split("<!-- MDOC !-->")
-             |> Enum.fetch!(1)
-
+  @moduledoc false
   require Logger
 
   @doc false
   def main(args) do
-    {opts, _, _} =
-      OptionParser.parse(args,
-        strict: [
-          url: :string,
-          debug: :boolean
-        ]
-      )
+    {opts, _} = OptionParser.parse!(args, strict: [debug: :boolean])
 
     base_url =
-      Keyword.get_lazy(opts, :url, fn -> System.get_env("SSE_URL") end) ||
-        raise "either --url or SSE_URL environment variable must be set"
+      case args do
+        [arg_url] ->
+          arg_url
+
+        [] ->
+          System.get_env("SSE_URL") ||
+            raise "either --url or SSE_URL environment variable must be set"
+
+        many ->
+          raise "expected one or zero arguments, got: #{inspect(many)}"
+      end
 
     debug = Keyword.get(opts, :debug, false)
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,8 +21,8 @@ defmodule McpProxy.MixProject do
   defp escript do
     [
       main_module: McpProxy,
-      name: "mcp_proxy",
-      path: "mcp_proxy"
+      name: "mcp-proxy",
+      path: "mcp-proxy"
     ]
   end
 
@@ -68,9 +68,10 @@ defmodule McpProxy.MixProject do
 
   defp docs do
     [
-      main: "McpProxy",
+      main: "readme",
       source_ref: "v#{@version}",
-      source_url: "https://github.com/tidewave-ai/mcp_proxy"
+      source_url: "https://github.com/tidewave-ai/mcp_proxy",
+      extras: ["README.md"]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,7 @@ defmodule McpProxy.MixProject do
 
   defp docs do
     [
+      api_reference: false,
       main: "readme",
       source_ref: "v#{@version}",
       source_url: "https://github.com/tidewave-ai/mcp_proxy",

--- a/test/mcp_proxy_test.exs
+++ b/test/mcp_proxy_test.exs
@@ -12,7 +12,7 @@ defmodule McpProxyTest do
     pid =
       spawn_link(fn ->
         Process.group_leader(self(), parent)
-        McpProxy.main(["--url", "http://localhost:#{port}/sse"])
+        McpProxy.main(["http://localhost:#{port}/sse"])
       end)
 
     assert_receive {:io_request, ^pid, reply_as, {:get_line, :unicode, []}}


### PR DESCRIPTION
By mirroring the executable and CLI args, the Tidewave instructions can be simpler.